### PR TITLE
Adding shared linter workflows.

### DIFF
--- a/.github/workflows/fix-linter-hints-pr.yml
+++ b/.github/workflows/fix-linter-hints-pr.yml
@@ -1,0 +1,61 @@
+name: Fixing linter hints in PR
+
+on:
+  workflow_call:
+    inputs:
+      workdirectory:
+        description: 'The root of the source tree which should be linted'
+        required: true
+        type: string
+
+jobs:
+  changedfiles:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      webif: ${{ steps.changes.outputs.webif }}
+    steps:
+      # Make sure we have some code to diff.
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changes
+        # Set outputs using the command.
+        run: |
+          echo "::set-output name=webif::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '\.[jt]s(x)?$' | sed s,${{ inputs.workdirectory }}/,, | xargs)"
+  lint:
+    runs-on: ubuntu-latest
+    needs: changedfiles
+    # only run there are changed files
+    if: ${{needs.changedfiles.outputs.webif}}
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdirectory }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Yarn cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles(inputs.workdirectory + '/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+          path: ~/.cache/yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Run lint --fix
+        continue-on-error: true
+        run: yarn lint:path --fix ${{needs.changedfiles.outputs.webif}}
+      - name: Commit changes
+        uses: Graylog2/add-and-commit@d77762158d703e60c60cf5baa4de52697d1414a3
+        with:
+          message: 'Fixing linter hints for you.'
+          add: 'src'
+          cwd: ${{ inputs.workdirectory }}
+          author_name: Dr. Lint-a-lot
+          author_email: garybot2@graylog.com
+          committer_name: Dr. Lint-a-lot
+          committer_email: garybot2@graylog.com
+

--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -1,0 +1,41 @@
+name: Fix linter hints
+
+on: 
+  workflow_call:
+    inputs:
+      workdirectory:
+        description: 'The root of the source tree which should be linted'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    defaults:
+      run:
+        working-directory: ${{ inputs.workdirectory }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Yarn cache
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-yarn-${{ hashFiles(inputs.workdirectory + '/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+          path: ~/.cache/yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Run lint --fix
+        continue-on-error: true
+        run: yarn lint --fix
+      - name: Create/Update Pull Request
+        uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
+        with:
+          title: Fixing linter hints automatically
+          body: This PR was created by a job that is running periodically to find and fix linter hints.
+          author: Dr. Lint-a-lot <garybot2@graylog.com>
+          branch: fix/linter-hints
+          committer: Dr. Lint-a-lot <garybot2@graylog.com>
+          commit-message: Running lint --fix
+          delete-branch: true


### PR DESCRIPTION
This PR is adding shared linter workflows which can be used to:

  - fix linter hints automatically on a schedule and create PRs if changes exist
  - fix linter hints for a PR and add changes as a separate commit to it

These workflows can be utilized in other repositories, so we have a central point to configure them.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging