### PR TITLE
Update `fix-linter-hints` workflow.

### DIFF
--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -19,6 +19,10 @@ jobs:
         java-version: [ 17 ]
 
     steps:
+      - name: Freeing up more disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - name: Checkout core repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run lint --fix
         continue-on-error: true
         run: yarn lint --fix
+      - name: Run lint:styles --fix
+        continue-on-error: true
+        run: yarn lint:styles --fix
       - name: Create/Update Pull Request
         uses: Graylog2/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad
         with:

--- a/.github/workflows/fix-linter-hints.yml
+++ b/.github/workflows/fix-linter-hints.yml
@@ -14,6 +14,9 @@ jobs:
     defaults:
       run:
         working-directory: plugin/${{ inputs.workingdirectory }}
+    strategy:
+      matrix:
+        java-version: [ 17 ]
 
     steps:
       - name: Checkout core repo
@@ -21,11 +24,12 @@ jobs:
         with:
           repository: Graylog2/graylog2-server
           path: graylog2-server
-      - name: Prepare core repo
-        working-directory: graylog2-server/graylog2-web-interface
-        run: |
-          yarn install
-          yarn build
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: temurin
+          cache: maven
       - uses: actions/checkout@v2
         with:
           path: plugin
@@ -36,8 +40,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
           path: ~/.cache/yarn
-      - name: Install dependencies
-        run: yarn install
+      - name: Build with Maven
+        run: mvn -B --fail-fast -Pedantic -Dspotbugs.skip -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -DskipTests compile
+        env:
+          JAVA_OPTS: -Xmx6G
       - name: Reset yarn lockfile
         run: git checkout yarn.lock
         continue-on-error: true


### PR DESCRIPTION
## Notes for Reviewers

The `fix-linter-hints` workflow is used to fix linter hints automatically in plugins. 
Currently the [related runs](https://github.com/Graylog2/graylog-plugin-enterprise/actions/runs/4977947392) fail, because the dependency `@graylog/server-api` can't be resolved, since it is generated when building the project with maven and the step is missing in the workflow.

With this PR we are building the project with maven. We are also including further steps
- to free up disc space
- to fix `stylelint` hints.