### PR TITLE
Clarifying security policy, removing outdated versions.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,7 @@
 
 ## Supported Versions
 
-Graylog is addressing vulnerabilities in the product for the current and the previous releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding) of the last twelve months.
-
-For the current release (4.0) this means:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 4.0.x   | :white_check_mark: |
-| 3.3.x   | :white_check_mark: |
-| < 3.3.0 | :x:                |
+Any reported vulnerability will be fixed for the (affected) current and the previous releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding). For older versions, it will still be published as a security advisory and fixed if the effort is reasonable.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This PR is removing ancient versions from the security policy and adjusts it according to our recent policy (last two versions, no time window of 12 months).

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

